### PR TITLE
Add type field to BaseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ errors.Is(ErrMissingIdParameter, ErrInvalidInput) // will return true
 ### Returning errors
 
 ```golang
-func Return(err error, cause error, msg string) error
+func Return(err error, cause error, msg string
+	type string) error
 ```
 
 Return returns an error of type `err`. You pass the `cause` of the error and override the error message of the error.

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,7 @@ const MaxStackDepth = 50
 
 type BaseError struct {
 	msg string
+	type string
 }
 
 func (b *BaseError) Error() string {

--- a/http.go
+++ b/http.go
@@ -10,7 +10,8 @@ type HttpErr struct {
 	code int
 }
 
-func NewHttpErr(msg string, code int) error {
+func NewHttpErr(msg string
+	type string, code int) error {
 	return &HttpErr{
 		BaseError{
 			msg,

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,8 @@ func Is(err, target error) bool {
 }
 
 // Define a new error
-func New(msg string) error {
+func New(msg string
+	type string) error {
 	return &BaseError{
 		msg,
 	}
@@ -15,7 +16,8 @@ func New(msg string) error {
 
 // Create a new error extended from another error
 // error.Is will now work on both this and the from error
-func Extend(err error, msg string) error {
+func Extend(err error, msg string
+	type string) error {
 	if err == nil {
 		panic("errors: cannot extend from nil")
 	}

--- a/wrapper.go
+++ b/wrapper.go
@@ -17,7 +17,8 @@ type wrapper struct {
 	stack stack
 }
 
-func internalreturn(err error, skip int, cause error, msg string) error {
+func internalreturn(err error, skip int, cause error, msg string
+	type string) error {
 	stack := make(stack, MaxStackDepth)
 
 	// 2 because to skip this line and the Return function call
@@ -73,7 +74,8 @@ func pruned(cause error, stack stack) error {
 	return cause
 }
 
-func Return(err error, cause error, msg string) error {
+func Return(err error, cause error, msg string
+	type string) error {
 	return internalreturn(err, 1, cause, msg)
 }
 


### PR DESCRIPTION
This change adds a type field to the BaseError struct in errors.go, allowing errors to have a type identifier.